### PR TITLE
remove specific cpu_arch

### DIFF
--- a/lib/webhook_destination-stack.ts
+++ b/lib/webhook_destination-stack.ts
@@ -12,7 +12,6 @@ export class WebhookDestinationStack extends cdk.Stack {
       runtime: cdk.aws_lambda.Runtime.NODEJS_22_X,
       memorySize: 256,
       timeout: cdk.Duration.seconds(30),
-      architecture: cdk.aws_lambda.Architecture.ARM_64,
       environment: {
         POWERTOOLS_SERVICE_NAME: id,
         POWERTOOLS_LOG_LEVEL: "INFO",


### PR DESCRIPTION
This causes the local build to fail on x86 machines. It doesn't need to be specified.